### PR TITLE
Use save-match-data in after-change hook.

### DIFF
--- a/emoji-cheat-sheet-plus.el
+++ b/emoji-cheat-sheet-plus.el
@@ -270,25 +270,26 @@
 (defun emoji-cheat-sheet-plus--display-region (start end)
   "Add emoji display properties to passed region."
   (save-excursion
-    (goto-char start)
-    (let ((inhibit-read-only t)
-          (modified (buffer-modified-p)))
-      (while (re-search-forward "\:[a-z0-9\\+_-]+?\:" end t)
-        (let* ((code (intern (match-string 0)))
-               (image (cdr (assq code emoji-cheat-sheet-plus-image--cache))))
-          (when image
-            ;; propertize only the inner code of the emoji
-            ;; the `:' are made invisible
-            ;; this allows to correctly render several contiguous
-            ;; occurrences of the same emoji
-            (let ((inhibit-modification-hooks t))
-              (add-text-properties
-               (match-beginning 0) (1+ (match-beginning 0))
-               '(invisible t emoji-cheat-sheet-plus-display t))
-              (add-text-properties
-               (1+ (match-beginning 0)) (match-end 0)
-               `(display ,image emoji-cheat-sheet-plus-display t))))))
-      (set-buffer-modified-p modified))))
+    (save-match-data
+      (goto-char start)
+      (let ((inhibit-read-only t)
+            (modified (buffer-modified-p)))
+        (while (re-search-forward "\:[a-z0-9\\+_-]+?\:" end t)
+          (let* ((code (intern (match-string 0)))
+                 (image (cdr (assq code emoji-cheat-sheet-plus-image--cache))))
+            (when image
+              ;; propertize only the inner code of the emoji
+              ;; the `:' are made invisible
+              ;; this allows to correctly render several contiguous
+              ;; occurrences of the same emoji
+              (let ((inhibit-modification-hooks t))
+                (add-text-properties
+                 (match-beginning 0) (1+ (match-beginning 0))
+                 '(invisible t emoji-cheat-sheet-plus-display t))
+                (add-text-properties
+                 (1+ (match-beginning 0)) (match-end 0)
+                 `(display ,image emoji-cheat-sheet-plus-display t))))))
+        (set-buffer-modified-p modified)))))
 
 (defun emoji-cheat-sheet-plus--undisplay-region (start end)
   "Remove emoji display properties from passed region."


### PR DESCRIPTION
* `emoji-cheat-sheet-plus.el` (`emoji-cheat-sheet-plus--display-region`): Use `save-match-data` in `emoji-cheat-sheet-plus--display-region` so that `emoji-cheat-sheet-plus--changed-hook` doesn't clobber match data.

This change avoids "Match data clobbered by buffer modification hooks" errors when something performs a search, then inserts text, and then uses `replace-match` in a buffer with `emoji-cheat-sheet-plus-display-mode` enabled, as in the following example:

```emacs-lisp
(search-backward "foo")
(save-excursion
  (goto-char (point-max))
  (insert "bar"))
(replace-match "baz")
```

Edit: This PR should fix https://github.com/syl20bnr/emacs-emoji-cheat-sheet-plus/issues/5.