### PR TITLE
Delete redundant use of match-string-no-properties.

### DIFF
--- a/emoji-cheat-sheet-plus.el
+++ b/emoji-cheat-sheet-plus.el
@@ -136,8 +136,7 @@
   (interactive)
   (let ((code (emoji-cheat-sheet-plus--code-under-point)))
     (when code
-      (when copy
-        (kill-new (match-string-no-properties 0)))
+      (when copy (kill-new code))
       (message (format "%s%s" code (if copy " (copied to kill ring)" ""))))))
 
 (defun emoji-cheat-sheet-plus-echo-and-copy ()


### PR DESCRIPTION
* `emoji-cheat-sheet-plus.el` (`emoji-cheat-sheet-plus-echo`): Replace a call to `match-string-no-properties` by using the value we already have from `emoji-cheat-sheet-plus--code-under-point`, which itself calls `match-string-no-properties`.