### PR TITLE
Fix "wrong side of point" for change above cur line

### DIFF
--- a/emoji-cheat-sheet-plus.el
+++ b/emoji-cheat-sheet-plus.el
@@ -265,7 +265,10 @@
 
 (defun emoji-cheat-sheet-plus--changed-hook (start end length)
   "Hook function for `after-change-functions' to display emoji image."
-  (emoji-cheat-sheet-plus--display-region (line-beginning-position) end))
+  (setq start (save-excursion
+                (goto-char start)
+                (line-beginning-position)))
+  (emoji-cheat-sheet-plus--display-region start end))
 
 (defun emoji-cheat-sheet-plus--display-region (start end)
   "Add emoji display properties to passed region."


### PR DESCRIPTION
Change the `after-change-functions` hook function not to assume that the beginning of the current line is contained in the range of changed text.

Before this commit, the hook function would cause an error when evaluating the following code in an empty buffer:

```emacs-lisp
(emoji-cheat-sheet-plus-display-mode 1)
(insert "a\nb")
(add-text-properties 1 2 '(foo bar)))
```

In this example, the range of changed text begins and ends on the first line, but point is on the second line, so `line-beginning-position` returns a position that is past the end of the range.

The hook function then calls `emoji-cheat-sheet-plus--display-region` with `start` and `end` values where `start` is past `end`.  This function moves point to `start` and calls `re-search-forward` with `end` as the bound, causing the following error:

    Invalid search bound (wrong side of point)

* `emoji-cheat-sheet-plus.el` (`emoji-cheat-sheet-plus--changed-hook`): Go to the beginning of the range of changed text before getting the line's beginning position.

---

A simpler solution would be to change `emoji-cheat-sheet-plus--changed-hook` to pass `start` straight through to `emoji-cheat-sheet-plus--display-region` (or even simply `(defalias 'emoji-cheat-sheet-plus--changed-hook 'emoji-cheat-sheet-plus--display-region)`) and change `emoji-cheat-sheet-plus--display-region` to do a `(beginning-of-line)` itself after `(goto-char start)`.  Looking at the other callers of `emoji-cheat-sheet-plus--display-region`, I don't think this change would cause any problems.  What do you think?